### PR TITLE
Fix empty partition assertion in unsorted sstable writing tools

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -175,6 +175,7 @@ public class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
         buffer = new Buffer();
         currentSize = 0;
         columnFamily = getColumnFamily();
+        buffer.setFirstInsertedKey(currentKey);
     }
 
     private void put(Buffer buffer) throws IOException
@@ -207,7 +208,17 @@ public class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
     }
 
     // typedef
-    private static class Buffer extends TreeMap<DecoratedKey, ColumnFamily> {}
+    private static class Buffer extends TreeMap<DecoratedKey, ColumnFamily> {
+        private DecoratedKey firstInsertedKey;
+
+        public void setFirstInsertedKey(DecoratedKey firstInsertedKey) {
+            this.firstInsertedKey = firstInsertedKey;
+        }
+
+        public DecoratedKey getFirstInsertedKey() {
+            return firstInsertedKey;
+        }
+    }
 
     private class DiskWriter extends Thread
     {
@@ -225,14 +236,12 @@ public class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
                         return;
 
                     writer = getWriter();
-                    boolean first = true;
                     for (Map.Entry<DecoratedKey, ColumnFamily> entry : b.entrySet())
                     {
                         if (entry.getValue().getColumnCount() > 0)
                             writer.append(entry.getKey(), entry.getValue());
-                        else if (!first)
+                        else if (!entry.getKey().equals(b.getFirstInsertedKey()))
                             throw new AssertionError("Empty partition");
-                        first = false;
                     }
                     writer.close(true);
                 }

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -22,6 +22,7 @@ import java.io.FilenameFilter;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
@@ -167,6 +168,34 @@ public class CQLSSTableWriterTest
         };
         assert tempdir.list(filterDataFiles).length > 1 : Arrays.toString(tempdir.list(filterDataFiles));
     }
+
+
+    @Test
+    public void testSyncNoEmptyRows() throws Exception
+    {
+        // Check that the write does not throw an empty partition error (#9071)
+        File tempdir = Files.createTempDir();
+        String schema = "CREATE TABLE ks.test2 ("
+                        + "  k UUID,"
+                        + "  c int,"
+                        + "  PRIMARY KEY (k)"
+                        + ")";
+        String insert = "INSERT INTO ks.test2 (k, c) VALUES (?, ?)";
+        CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                  .inDirectory(tempdir)
+                                                  .forTable(schema)
+                                                  .withPartitioner(StorageService.instance.getPartitioner())
+                                                  .using(insert)
+                                                  .withBufferSizeInMB(1)
+                                                  .build();
+
+        for (int i = 0 ; i < 50000 ; i++) {
+            writer.addRow(UUID.randomUUID(), 0);
+        }
+        writer.close();
+
+    }
+
 
 
     private static final int NUMBER_WRITES_IN_RUNNABLE = 10;


### PR DESCRIPTION
patch by Fabien Rousseau; reviewed by benedict for CASSANDRA-9071

Conflicts:
    CHANGES.txt

cherry-picking fix from 2.1.x.  This will allow us to use >= 2.0.11, so we can take advantage of DateTieredCompactionStrategy.
